### PR TITLE
two fixes for git clone of xc-vusb

### DIFF
--- a/do_build.ps1
+++ b/do_build.ps1
@@ -103,14 +103,14 @@ if ($doclone) {
 	    # standard practice on XT is to fall back to master for
 	    # branches that do not exist.
             if (-Not ($LastExitCode -eq 0)) {
-                 Invoke-CommandChecked "git checkout" $gitbin -q -b $branch
+                 Invoke-CommandChecked "git checkout" $gitbin checkout -q -b $branch
             }
         } 
         Pop-Location 
     } elseif ($tag.Length -gt 0) {
        Push-Location -Path "xc-vusb"
        Write-Host ("Checking out: " + $tag + " For: xc-vusb")
-       Invoke-CommandChecked "git checkout tag for xc-vusb" $gitbin -q -b $tag $tag 
+       Invoke-CommandChecked "git checkout tag for xc-vusb" $gitbin checkout -q -b $tag $tag 
        Pop-Location
     } else {
        throw "No branch or tag for xc-vusb checkout"


### PR DESCRIPTION
Jed wins the prize for actually being the first to try this code and spotting the xc-vusb clone was borked. Sorry.

Fixes:
1. $false and $true were spelled false and true, which broke the logic
2. There were a couple of errors in the git invocations.

Essentially and embarassingly the code path taken on first use of this
was untested in the version I sent for review before. But this time I
have tested this path. I need a better way to set the git cloning URLs
to my own so that I safely delete everything and do a clean rebuild.
