### PR TITLE
Fix xen bus device reference count handling to prevent leaks.

### DIFF
--- a/xenevtchn/xenevtchn.h
+++ b/xenevtchn/xenevtchn.h
@@ -96,6 +96,7 @@ struct xenbus_device {
     unsigned was_connected:1;
     unsigned bus_rescan_needed:1;
     unsigned surprise_remove:1;
+    unsigned class_changed_deref:1;
 };
 
 #define XS_DELAY_REMOVAL_US 5000000


### PR DESCRIPTION
This is a somewhat minimal attempt to fix the xen device reference
counting. There are a number of comments in the code to give an idea
of what is going on. The exhaustion of resources seen while testing
vusb device plug/unplug was caused by improper reference counting
leading to leaked memory and xenbus resources. This also fixes the
same leaks when vif/vwif devices are disconnected and connected.

OXT-70

Signed-of-by: Ross Philipson ross.philipson@gmail.com
