### PR TITLE
Removing XenClient Branding from Test Data

### DIFF
--- a/wnet/xenwnet/wlan.c
+++ b/wnet/xenwnet/wlan.c
@@ -118,7 +118,7 @@ WlanGetBackendValues (
 
     /* TODO this is just test data */
     NdisMoveMemory(WlanAdapter->XenBSSID, "\x00\x1D\xE0\x97\xAA\x33", sizeof(NDIS_802_11_MAC_ADDRESS));
-    NdisMoveMemory(WlanAdapter->XenSSID.Ssid, "XenClient Wireless", 11);
+    NdisMoveMemory(WlanAdapter->XenSSID.Ssid, "OpenXT Wireless", 11);
     WlanAdapter->XenSSID.SsidLength = 11;
     WlanAdapter->XenConnected = TRUE;
 


### PR DESCRIPTION
This change removes further XenClient branding from the OpenXT project. The string that has been changed is labelled as test data. Additionally, the only function call to this code is commented out on line 101 of the same file. 

This PR is in reference to:
https://github.com/OpenXT/network/pull/1#issuecomment-163452609
https://openxt.atlassian.net/browse/OXT-452