### PR TITLE
Fix assumption about scsifilt shared ring

### DIFF
--- a/scsifilt/controlpath.c
+++ b/scsifilt/controlpath.c
@@ -88,12 +88,14 @@ static void
 grant_ring(struct scsifilt *sf)
 {
     DOMAIN_ID domid = sf->backend_domid;
-    ULONG_PTR frame = virt_to_pfn(sf->ring_shared);
+    ULONG_PTR frame;
     int i;
 
     ungrant_ring(sf);
 
     for (i = 0; i < (1 << sf->ring_order); i++) {
+        frame = virt_to_pfn((void*) ((ULONG_PTR)sf->ring_shared + 
+                                     (ULONG_PTR)((i)*PAGE_SIZE)));
         sf->ring_gref[i] = GnttabGrantForeignAccessCache(domid,
                                                          frame,
                                                          GRANT_MODE_RW,
@@ -102,8 +104,6 @@ grant_ring(struct scsifilt *sf)
         /* Because the grant cache always contains enough grefs to cover
            the ring itself. */
         XM_ASSERT(!is_null_GRANT_REF(sf->ring_gref[i]));
-
-        frame++;
     }
 }
 


### PR DESCRIPTION
The scsifilt shared ring is multiple pages, and its
grant call was setup incorrectly. This worked fine in
Windows 7 and earlier, however it appears Windows 10
is less inclined to have virtually allocated memory
have a contiguous backing store, even for very small
allocations (4 pages in this case).

Signed-off-by: Brendan Kerrigan <kerriganb@ainfosec.com>