### PR TITLE
Remove disk-related drivers from the build

### DIFF
--- a/dirs
+++ b/dirs
@@ -3,7 +3,6 @@ DIRS=removedev \
      xenevtchn \
      net \
      wnet \
-     xenvbd \
      xenuser \
      xenv4v \
      enableuninst \
@@ -11,13 +10,11 @@ DIRS=removedev \
      install \
      setloglevel \
      getlogs \
-     scsifilt \
      query_balloon \
      xenvesa \
      sync \
      sockpipe \
      uninst_pending \
      copyvif \
-     fixdiskfilters \
      input \
-	 xenaud
+     xenaud


### PR DESCRIPTION
This is removing our custom fork of the Windows pv disk driver.
On top of being unreliable, this custom driver doesn't have any advantage over AHCI emulation.
I tested speed and battery usage, and both results came out very similar.
In the future, we will switch to the upstream disk frontend driver.

One notable downside is the following scenario:
- Install the OpenXT version that precedes this PR
- Create a Windows VM with tools
- Upgrade to an OpenXT version that does includes this PR
- Upgrade the tools inside the VM (uninstall/install)
-> the VM will use IDE emulation, which is considerably less efficient than AHCI.
It is however easy to fix, just switch to AHCI in xenmgr and inside the guest.

Signed-off-by: Jed <lejosnej@ainfosec.com>