### PR TITLE
build: Amend configuration for build and signature.

### DIFF
--- a/OxtService/OxtService.vcxproj
+++ b/OxtService/OxtService.vcxproj
@@ -89,10 +89,6 @@
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
-    <PostBuildEvent>
-      <Message>Performing registration</Message>
-      <Command>"$(TargetPath)" /RegServer</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Midl>
@@ -130,10 +126,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
-    <PostBuildEvent>
-      <Message>Performing registration</Message>
-      <Command>"$(TargetPath)" /RegServer</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="poweropts.c" />

--- a/doverifysign.ps1
+++ b/doverifysign.ps1
@@ -7,11 +7,11 @@ Import-Module $ScriptDir\..\BuildSupport\invoke.psm1
 
 Write-Host "signtool $signtool"
 Push-Location sign32
-Invoke-CommandChecked "Check 32 bit CAT files" $signtool verify /pa /v xennet.cat xenwnet.cat xenvbd.cat xenvesa-xp.cat xenvesa-lh.cat xenv4v.cat xevtchn.cat xeninp.cat xenaud.cat
-Invoke-CommandChecked "Check 32 bit boot start drivers" $signtool verify /pa /v xevtchn.sys xenv4v.sys xenvbd.sys xenvesa-miniport.sys xenvesa-display.dll scsifilt.sys xennet.sys xennet6.sys xenwnet.sys xenwnet6.sys xenutil.sys xeninp.sys xenaud.sys
+Invoke-CommandChecked "Check 32 bit CAT files" $signtool verify /pa /v xennet.cat xenwnet.cat xenvesa-xp.cat xenvesa-lh.cat xenv4v.cat xevtchn.cat xeninp.cat xenaud.cat
+Invoke-CommandChecked "Check 32 bit boot start drivers" $signtool verify /pa /v xevtchn.sys xenv4v.sys xenvesa-miniport.sys xenvesa-display.dll xennet.sys xennet6.sys xenwnet.sys xenwnet6.sys xenutil.sys xeninp.sys xenaud.sys
 Pop-Location
 
 Push-Location sign64
-Invoke-CommandChecked "Check 64 bit CAT files" $signtool verify /pa /v xennet.cat xenwnet.cat xenvbd.cat  xenvesa-xp.cat xenvesa-lh.cat xenv4v.cat xevtchn.cat xeninp.cat xenaud.cat
-Invoke-CommandChecked "Checked 64 bit boot start drivers" $signtool verify /pa /v xevtchn.sys xenv4v.sys xenvbd.sys xenvesa-miniport.sys xenvesa-display.dll scsifilt.sys xennet.sys xennet6.sys xenwnet.sys xenwnet6.sys xenutil.sys xeninp.sys xenaud.sys
+Invoke-CommandChecked "Check 64 bit CAT files" $signtool verify /pa /v xennet.cat xenwnet.cat xenvesa-xp.cat xenvesa-lh.cat xenv4v.cat xevtchn.cat xeninp.cat xenaud.cat
+Invoke-CommandChecked "Checked 64 bit boot start drivers" $signtool verify /pa /v xevtchn.sys xenv4v.sys xenvesa-miniport.sys xenvesa-display.dll xennet.sys xennet6.sys xenwnet.sys xenwnet6.sys xenutil.sys xeninp.sys xenaud.sys
 Pop-Location


### PR DESCRIPTION
- OxtService defined `PostBuildEvent` that called the produced OxtService to register it as a service on the build machine. This might have been a debug step introduced early for quick testing?
- Remove `scsifilt.sys` and `xenvbd.sys` from `doverifysign.ps1` since they are no longer built. This only fails for `Release` type builds.